### PR TITLE
Adding hidden devices, but not making them visible

### DIFF
--- a/custom_components/plejd/plejd_entity.py
+++ b/custom_components/plejd/plejd_entity.py
@@ -39,6 +39,11 @@ class PlejdDeviceBaseEntity(Entity):
         """Return unique identifier for the entity."""
         return f"{self.device.BLEaddress}:{self.device.address}"
 
+    @property
+    def entity_registry_visible_default(self):
+        """Return if the device should be visible by default"""
+        return not self.device.hidden
+
     @callback
     def _handle_state_update(self, data) -> None:
           """When device state is updated from Plejd"""

--- a/custom_components/plejd/plejd_site.py
+++ b/custom_components/plejd/plejd_site.py
@@ -86,8 +86,6 @@ class PlejdSite:
         self.scenes = self.manager.scenes
 
         for device in self.devices:
-            if device.hidden:
-                continue
             if (adder := self.add_device_callbacks.get(device.outputType)):
                 adder(device)
             else:


### PR DESCRIPTION
With this change devices that are hidden in Plejd will now be added (no longer ignored) but visibility set by the integration to be false.

An example of a "hidden" device:
<img width="1017" alt="Screenshot 2024-05-10 at 09 14 32" src="https://github.com/thomasloven/hass-plejd/assets/994715/6a5f5d2a-bd58-49b1-8e93-aa3ea7f6c3c1">

The settings of the switch (in this case) that's now not visible by default:
<img width="562" alt="Screenshot 2024-05-10 at 09 14 48" src="https://github.com/thomasloven/hass-plejd/assets/994715/5db46a79-83a1-4820-9cc9-82ed7d7c5ce0">
