### PR TITLE
Not pinging when new device is discovered

### DIFF
--- a/custom_components/plejd/plejd_site.py
+++ b/custom_components/plejd/plejd_site.py
@@ -121,7 +121,7 @@ class PlejdSite:
         # Run through already discovered devices and add plejds to the manager
         for service_info in bluetooth.async_discovered_service_info(self.hass, True):
             if pyplejd.PLEJD_SERVICE.lower() in service_info.advertisement.service_uuids:
-                self._discovered(service_info, connect=False)
+                self._discovered(service_info)
 
         # Ping the mesh periodically to maintain the connection
         self.config_entry.async_on_unload(
@@ -152,11 +152,9 @@ class PlejdSite:
         await self.manager.disconnect()
 
 
-    def _discovered(self, service_info: BluetoothServiceInfoBleak, *_, connect: bool = True) -> None:
+    def _discovered(self, service_info: BluetoothServiceInfoBleak, *_) -> None:
         """Register any discovered plejd device with the manager."""
         self.manager.add_mesh_device(service_info.device, service_info.rssi)
-        if connect:
-            self.hass.async_create_task(self._ping())
 
     async def _ping(self, *_) -> None:
         """Ping the plejd mesh to connect or maintain the connection."""


### PR DESCRIPTION
Related to https://github.com/thomasloven/hass-plejd/issues/66.

It seems that doing a ping when a new device is discovered causes flooding of Bluetooth traffic. Not sure if this happens to everyone but for me I get quite a lot of "discovered" events, even from Bluetooth devices that are not Plejd. Every time this happens it triggers a ping, which in turn discovers more devices.

I added some logging in the `_discovered` function and this is a sample of what I see in my HA logs:

```
2024-05-26 08:42:15.040 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:15.109 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:17.299 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:17.360 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:17.886 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:17.959 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:19.340 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:19.511 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:19.806 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:20.116 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:20.545 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:20.716 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:21.326 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:21.495 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:23.048 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:23.133 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:26.076 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:26.333 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:30.667 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:30.720 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:32.539 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:32.629 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:35.045 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
2024-05-26 08:42:35.215 INFO (MainThread) [custom_components.plejd.plejd_site] Discovered device S19 A86D LE
```

I don't know why the ping was added in the first place, but I've removed it and has been running flawlessly on my HA for weeks now.