### PR TITLE
Only ping if the device discovered is new

### DIFF
--- a/custom_components/plejd/plejd_site.py
+++ b/custom_components/plejd/plejd_site.py
@@ -154,8 +154,8 @@ class PlejdSite:
 
     def _discovered(self, service_info: BluetoothServiceInfoBleak, *_, connect: bool = True) -> None:
         """Register any discovered plejd device with the manager."""
-        self.manager.add_mesh_device(service_info.device, service_info.rssi)
-        if connect:
+        new_device = self.manager.add_mesh_device(service_info.device, service_info.rssi)
+        if connect and new_device:
             self.hass.async_create_task(self._ping())
 
     async def _ping(self, *_) -> None:


### PR DESCRIPTION
Depends on https://github.com/thomasloven/pyplejd/pull/7 to be merged first and version bump to happen in this repo.

Only sends out a ping on discovery when the device was new. Seems like `_discovered` will be called multiple times for the same device, even if it was added before. This is to prevent ping flooding as described in issue https://github.com/thomasloven/hass-plejd/issues/66.